### PR TITLE
Mention that tests need a Python-enabled gdb.

### DIFF
--- a/src/tests/running.md
+++ b/src/tests/running.md
@@ -19,6 +19,10 @@ timestamp file for every test can be found under `build/ARCH/test/`.
 To force-rerun a test (e.g. in case the test runner fails to notice
 a change) you can simply remove the timestamp file.
 
+Note that some tests require a Python-enabled gdb. If you are building
+gdb from source, you need to configure with
+`--with-python=<path-to-python-binary>`.
+
 ## Running a subset of the test suites
 
 When working on a specific PR, you will usually want to run a smaller

--- a/src/tests/running.md
+++ b/src/tests/running.md
@@ -19,8 +19,10 @@ timestamp file for every test can be found under `build/ARCH/test/`.
 To force-rerun a test (e.g. in case the test runner fails to notice
 a change) you can simply remove the timestamp file.
 
-Note that some tests require a Python-enabled gdb. If you are building
-gdb from source, you need to configure with
+Note that some tests require a Python-enabled gdb. You can test if
+your gdb install supports Python by using the `python` command from
+within gdb (type some Python code followed by `CTRL+D` to execute it).
+If you are building gdb from source, you need to configure with
 `--with-python=<path-to-python-binary>`.
 
 ## Running a subset of the test suites

--- a/src/tests/running.md
+++ b/src/tests/running.md
@@ -21,8 +21,9 @@ a change) you can simply remove the timestamp file.
 
 Note that some tests require a Python-enabled gdb. You can test if
 your gdb install supports Python by using the `python` command from
-within gdb (type some Python code followed by `CTRL+D` to execute it).
-If you are building gdb from source, you need to configure with
+within gdb. Once invoked you can type some Python code (e.g.
+`print("hi")`) followed by return and then `CTRL+D` to execute it.
+If you are building gdb from source, you will need to configure with
 `--with-python=<path-to-python-binary>`.
 
 ## Running a subset of the test suites


### PR DESCRIPTION
As mentioned here:
https://github.com/rust-lang/rust/issues/52452#issuecomment-440354255

It would be good is the rust compiler guide mentioned that the compiler tests need gdb with Python support.

Are there any other test dependencies that we should mention? If there are a few, perhaps we'd even want a subsection listing them.

Thanks