### PR TITLE
fix issues link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The guide can be useful today, but it has a lot of work still go.
 
 If you'd like to help improve the guide, we'd love to have you! You can find
 plenty of issues on the [issue
-tracker](https://github.com/rust-lang-nursery/rustc-guide/issue). Just post a
+tracker](https://github.com/rust-lang/rustc-guide/issue). Just post a
 comment on the issue you would like to work on to make sure that we don't
 accidentally duplicate work. If you think something is missing, please open an
 issue about it!

--- a/src/about-this-guide.md
+++ b/src/about-this-guide.md
@@ -11,4 +11,4 @@ be found at the [GitHub repository]. If you find any mistakes in the
 guide, please file an issue about it, or even better, open a PR
 with a correction!
 
-[GitHub repository]: https://github.com/rust-lang-nursery/rustc-guide/
+[GitHub repository]: https://github.com/rust-lang/rustc-guide/

--- a/src/diag.md
+++ b/src/diag.md
@@ -81,7 +81,7 @@ suggestions pleasingly in the terminal, or (when the `--error-format json` flag
 is passed) as JSON for consumption by tools, most notably the [Rust Language
 Server][rls] and [`rustfix`][rustfix].
 
-[rls]: https://github.com/rust-lang-nursery/rls
+[rls]: https://github.com/rust-lang/rls
 [rustfix]: https://github.com/rust-lang-nursery/rustfix
 
 Not all suggestions should be applied mechanically. Use the


### PR DESCRIPTION
The `issues` link in the root has linkrotted since this is no longer `rust-lang-nursery`, just updating it.

I also found another two links that aren't quite right but still redirect correctly:
`rls` in `src/diag.md` - rls has also moved out of nursery
`Github repository` in `src/about-this-guide.md` - that's a link to this repo but under `rust-lang-nursery`

Should I update those links as well? I'm not sure if github redirects remain valid forever and I don't want to go just changing stuff around willy nilly