### PR TITLE
Fix link to rustc_mir::hair::cx::expr

### DIFF
--- a/src/mir/construction.md
+++ b/src/mir/construction.md
@@ -24,9 +24,8 @@ being a `hair::ExprKind::Neg(hair::Expr)` it is a `hair::ExprKind::Neg(hir::Expr
 This shallowness enables the `HAIR` to represent all datatypes that [HIR] has, but
 without having to create an in-memory copy of the entire [HIR].
 [MIR] lowering will first convert the topmost expression from
-[HIR] to [HAIR] (in
-[https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir/hair/cx/expr/index.html])
-and then process the [HAIR] expressions recursively.
+[HIR] to [HAIR] (in [rustc_mir::hair::cx::expr]) and then process
+the [HAIR] expressions recursively.
 
 The lowering creates local variables for every argument as specified in the signature.
 Next it creates local variables for every binding specified (e.g. `(a, b): (i32, String)`)
@@ -147,4 +146,6 @@ case of `enum`s.
 [MIR]: ./index.html
 [HIR]: ../hir.html
 [HAIR]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir/hair/index.html
+
+[rustc_mir::hair::cx::expr]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir/hair/cx/expr/index.html
 [`mir_built`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir/transform/fn.mir_built.html


### PR DESCRIPTION
It currently looks like the following:

(in [https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir/hair/cx/expr/index.html])

This makes it look like:

(in [rustc_mir::hair::cx::expr])

[rustc_mir::hair::cx::expr]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir/hair/cx/expr/index.html