### PR TITLE
Add experts map section to compiler team page

### DIFF
--- a/src/compiler-team.md
+++ b/src/compiler-team.md
@@ -17,6 +17,14 @@ home. In any case, you can find people in one of three places at the moment:
 - The `t-compiler` stream on [the Zulip instance](https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler)
 - The `compiler` channel on the [rust-lang discord](https://discord.gg/rust-lang)
 
+## Expert map
+
+If you're interested in figuring out who can answer questions about a
+particular part of the compiler, or you'd just like to know who works on what,
+check out our [experts directory](https://github.com/rust-lang/compiler-team/blob/master/experts/MAP.md).
+It contains a listing of the various parts of the compiler and a list of people
+who are experts on each one.
+
 ## Rust compiler meeting
 
 The compiler team has a weekly meeting where we do triage and try to


### PR DESCRIPTION
@nikomatsakis @davidtwco added a section to link the experts map.