### PR TITLE
Update link to debugging codegen

### DIFF
--- a/src/codegen.md
+++ b/src/codegen.md
@@ -4,9 +4,9 @@ Code generation or "codegen" is the part of the compiler that actually
 generates an executable binary. rustc uses LLVM for code generation.
 
 > NOTE: If you are looking for hints on how to debug code generation bugs,
-> please see [this section of the debugging chapter][debug].
+> please see [this section of the debugging chapter][debugging].
 
-[debug]: compiler-debugging.html#debugging-llvm
+[debugging]: codegen/debugging.html
 
 ## What is LLVM?
 


### PR DESCRIPTION
The debugging LLVM page was moved into the Code Generation section