### PR TITLE
Fix link in walkthrough

### DIFF
--- a/src/walkthrough.md
+++ b/src/walkthrough.md
@@ -258,6 +258,8 @@ After this, [a PR is made][stab] to remove the feature gate, enabling the featur
 default (on the 2018 edition). A note is added to the [Release notes][relnotes]
 about the feature.
 
+[stab]: https://github.com/rust-lang/rust/pull/56245
+
 Steps to stabilize the feature can be found at [Stabilizing Features](./stabilization_guide.md).
 
 [relnotes]: https://github.com/rust-lang/rust/blob/master/RELEASES.md


### PR DESCRIPTION
It seems there is a missing link to the  stabilization report in the [current walkthrough document](https://rust-lang.github.io/rustc-guide/walkthrough.html), near the very end of the page. 

I looked for the stabilization PR mentioned and I believe I found the right one. I linked it in the Markdown file.