### PR TITLE
Renamed the file and title of the diagnostics chapter.

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -21,6 +21,8 @@
     - [with the linux perf tool](./profiling/with_perf.md)
 - [Coding conventions](./conventions.md)
 - [crates.io Dependencies](./crates-io.md)
+- [Emitting Errors and other Diagnostics](diagnostics.md)
+  - [JSON diagnostic format](diagnostics/json-format.md)
 
 ---
 
@@ -83,8 +85,6 @@
 - [Code Generation](./codegen.md)
   - [Updating LLVM](./codegen/updating-llvm.md)
   - [Debugging LLVM](./codegen/debugging.md)
-- [Emitting Diagnostics](./diag.md)
-  - [JSON diagnostic format](./diag/json-format.md)
 - [Profile-guided Optimization](./profile-guided-optimization.md)
 
 ---

--- a/src/appendix/code-index.md
+++ b/src/appendix/code-index.md
@@ -38,7 +38,7 @@ Item            |  Kind    | Short description           | Chapter            | 
 [Type checking]: ../type-checking.html
 [The `ty` modules]: ../ty.html
 [Rustdoc]: ../rustdoc.html
-[Emitting Diagnostics]: ../diag.html
+[Emitting Diagnostics]: ../diagnostics.html
 [Macro expansion]: ../macro-expansion.html
 [Name resolution]: ../name-resolution.html
 [Parameter Environment]: ../param_env.html

--- a/src/diagnostics.md
+++ b/src/diagnostics.md
@@ -1,4 +1,4 @@
-# Emitting Diagnostics
+# Emitting Errors and other Diagnostics
 
 A lot of effort has been put into making `rustc` have great error messages.
 This chapter is about how to emit compile errors and lints from the compiler.

--- a/src/implementing_new_features.md
+++ b/src/implementing_new_features.md
@@ -49,7 +49,7 @@ In some cases, a feature or bugfix might break some existing programs
 in some edge cases. In that case, you might want to do a crater run
 to assess the impact and possibly add a future-compatibility lint,
 similar to those used for
-[edition-gated lints](./diag.md#edition-gated-lints).
+[edition-gated lints](diagnostics.md#edition-gated-lints).
 
 ### Stability
 


### PR DESCRIPTION
When I recently searched for infos in this guide on how to create a warning, I couldn't find any. Later I found it through #14.

The reason was that I didn't know the term 'diagnostics' and that it is the collective term for errors, warnings and lints.

Renaming the chapter to include the word 'error' should help. I think also including 'warning' in the title shouldn't be neccessary, because it's close enough.