### PR TITLE
Update for TyCtxt<'a, 'gcx, 'tcx> -> TyCtxt<'tcx>.

### DIFF
--- a/src/appendix/code-index.md
+++ b/src/appendix/code-index.md
@@ -29,7 +29,7 @@ Item            |  Kind    | Short description           | Chapter            | 
 `TraitDef` | struct | This struct contains a trait's definition with type information | [The `ty` modules] |  [src/librustc/ty/trait_def.rs](https://doc.rust-lang.org/nightly/nightly-rustc/rustc/ty/trait_def/struct.TraitDef.html)
 `TraitRef` | struct | The combination of a trait and its input types (e.g. `P0: Trait<P1...Pn>`) | [Trait Solving: Goals and Clauses], [Trait Solving: Lowering impls]  |  [src/librustc/ty/sty.rs](https://doc.rust-lang.org/nightly/nightly-rustc/rustc/ty/struct.TraitRef.html)
 `Ty<'tcx>` | struct | This is the internal representation of a type used for type checking | [Type checking] | [src/librustc/ty/mod.rs](https://doc.rust-lang.org/nightly/nightly-rustc/rustc/ty/type.Ty.html)
-`TyCtxt<'cx, 'tcx, 'tcx>` | struct | The "typing context". This is the central data structure in the compiler. It is the context that you use to perform all manner of queries | [The `ty` modules] | [src/librustc/ty/context.rs](https://doc.rust-lang.org/nightly/nightly-rustc/rustc/ty/struct.TyCtxt.html)
+`TyCtxt<'tcx>` | struct | The "typing context". This is the central data structure in the compiler. It is the context that you use to perform all manner of queries | [The `ty` modules] | [src/librustc/ty/context.rs](https://doc.rust-lang.org/nightly/nightly-rustc/rustc/ty/struct.TyCtxt.html)
 
 [The HIR]: ../hir.html
 [Identifiers in the HIR]: ../hir.html#hir-id

--- a/src/appendix/glossary.md
+++ b/src/appendix/glossary.md
@@ -25,7 +25,6 @@ early-bound lifetime    |  a lifetime region that is substituted at its definiti
 empty type              |  see "uninhabited type".
 Fat pointer             |  a two word value carrying the address of some value, along with some further information necessary to put the value to use. Rust includes two kinds of "fat pointers": references to slices, and trait objects. A reference to a slice carries the starting address of the slice and its length. A trait object carries a value's address and a pointer to the trait's implementation appropriate to that value. "Fat pointers" are also known as "wide pointers", and "double pointers".
 free variable           |  a "free variable" is one that is not bound within an expression or term; see [the background chapter for more](./background.html#free-vs-bound)
-'gcx                    |  the lifetime of the global arena ([see more](../ty.html))
 generics                |  the set of generic type parameters defined on a type or item
 HIR                     |  the High-level IR, created by lowering and desugaring the AST ([see more](../hir.html))
 HirId                   |  identifies a particular node in the HIR by combining a def-id with an "intra-definition offset".

--- a/src/compiler-debugging.md
+++ b/src/compiler-debugging.md
@@ -48,7 +48,7 @@ stack backtrace:
 
 If you want line numbers for the stack trace, you can enable `debug = true` in
 your config.toml and rebuild the compiler (`debuginfo-level = 1` will also add
-line numbers, but `debug = true` gives full debuginfo). Then the backtrace will 
+line numbers, but `debug = true` gives full debuginfo). Then the backtrace will
 look like this:
 
 ```text
@@ -129,11 +129,11 @@ note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose
 backtrace.
 stack backtrace:
   (~~~ IRRELEVANT PART OF BACKTRACE REMOVED BY ME ~~~)
-   7: rustc::traits::error_reporting::<impl rustc::infer::InferCtxt<'a, 'gcx,
-             'tcx>>::report_selection_error
+   7: rustc::traits::error_reporting::<impl rustc::infer::InferCtxt<'a, 'tcx>>
+             ::report_selection_error
              at /home/user/rust/src/librustc/traits/error_reporting.rs:823
-   8: rustc::traits::error_reporting::<impl rustc::infer::InferCtxt<'a, 'gcx,
-             'tcx>>::report_fulfillment_errors
+   8: rustc::traits::error_reporting::<impl rustc::infer::InferCtxt<'a, 'tcx>>
+             ::report_fulfillment_errors
              at /home/user/rust/src/librustc/traits/error_reporting.rs:160
              at /home/user/rust/src/librustc/traits/error_reporting.rs:112
    9: rustc_typeck::check::FnCtxt::select_obligations_where_possible

--- a/src/conventions.md
+++ b/src/conventions.md
@@ -141,8 +141,7 @@ to the compiler.
 - `cx` tends to be short for "context" and is often used as a suffix. For
   example, `tcx` is a common name for the [Typing Context][tcx].
 
-- [`'tcx` and `'gcx`][tcx] are used as the lifetime names for the Typing
-  Context.
+- [`'tcx`][tcx] is used as the lifetim names for the Typing Context.
 
 - Because `crate` is a keyword, if you need a variable to represent something
   crate-related, often the spelling is changed to `krate`.

--- a/src/mir/visitor.md
+++ b/src/mir/visitor.md
@@ -15,7 +15,7 @@ state you will need while processing MIR:
 
 ```rust,ignore
 struct MyVisitor<...> {
-    tcx: TyCtxt<'cx, 'tcx, 'tcx>,
+    tcx: TyCtxt<'tcx>,
     ...
 }
 ```

--- a/src/profiling/with_perf.md
+++ b/src/profiling/with_perf.md
@@ -272,9 +272,9 @@ Tree
 : : | rustc_mir::borrow_check::nll::type_check::type_check_internal (13% total, 0% self)
 : : : | core::ops::function::FnOnce::call_once (5% total, 0% self)
 : : : : | rustc_mir::borrow_check::nll::type_check::liveness::generate (5% total, 3% self)
-: : : | <rustc_mir::borrow_check::nll::type_check::TypeVerifier<'a, 'b, 'gcx, 'tcx> as rustc::mir::visit::Visitor<'tcx>>::visit_mir (3% total, 0% self)
+: : : | <rustc_mir::borrow_check::nll::type_check::TypeVerifier<'a, 'b, 'tcx> as rustc::mir::visit::Visitor<'tcx>>::visit_mir (3% total, 0% self)
 : | rustc::mir::visit::Visitor::visit_mir (8% total, 6% self)
-: | <rustc_mir::borrow_check::MirBorrowckCtxt<'cx, 'gcx, 'tcx> as rustc_mir::dataflow::DataflowResultsConsumer<'cx, 'tcx>>::visit_statement_entry (5% total, 0% self)
+: | <rustc_mir::borrow_check::MirBorrowckCtxt<'cx, 'tcx> as rustc_mir::dataflow::DataflowResultsConsumer<'cx, 'tcx>>::visit_statement_entry (5% total, 0% self)
 : | rustc_mir::dataflow::do_dataflow (3% total, 0% self)
 ```
 
@@ -321,7 +321,7 @@ Tree
 | matched `{do_mir_borrowck}` (100% total, 0% self)
 : | rustc_mir::borrow_check::nll::compute_regions (47% total, 0% self) [...]
 : | rustc::mir::visit::Visitor::visit_mir (19% total, 15% self) [...]
-: | <rustc_mir::borrow_check::MirBorrowckCtxt<'cx, 'gcx, 'tcx> as rustc_mir::dataflow::DataflowResultsConsumer<'cx, 'tcx>>::visit_statement_entry (13% total, 0% self) [...]
+: | <rustc_mir::borrow_check::MirBorrowckCtxt<'cx, 'tcx> as rustc_mir::dataflow::DataflowResultsConsumer<'cx, 'tcx>>::visit_statement_entry (13% total, 0% self) [...]
 : | rustc_mir::dataflow::do_dataflow (8% total, 1% self) [...]
 ```
 

--- a/src/query.md
+++ b/src/query.md
@@ -82,17 +82,15 @@ on how that works).
 Providers always have the same signature:
 
 ```rust,ignore
-fn provider<'cx, 'tcx>(tcx: TyCtxt<'cx, 'tcx, 'tcx>,
-                       key: QUERY_KEY)
-                       -> QUERY_RESULT
-{
+fn provider<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    key: QUERY_KEY,
+) -> QUERY_RESULT {
     ...
 }
 ```
 
-Providers take two arguments: the `tcx` and the query key. Note also
-that they take the *global* tcx (i.e. they use the `'tcx` lifetime
-twice), rather than taking a tcx with some active inference context.
+Providers take two arguments: the `tcx` and the query key.
 They return the result of the query.
 
 ####  How providers are setup
@@ -103,7 +101,7 @@ is basically a big list of function pointers:
 
 ```rust,ignore
 struct Providers {
-    type_of: for<'cx, 'tcx> fn(TyCtxt<'cx, 'tcx, 'tcx>, DefId) -> Ty<'tcx>,
+    type_of: for<'tcx> fn(TyCtxt<'tcx>, DefId) -> Ty<'tcx>,
     ...
 }
 ```
@@ -144,7 +142,7 @@ pub fn provide(providers: &mut Providers) {
     };
 }
 
-fn fubar<'cx, 'tcx>(tcx: TyCtxt<'cx, 'tcx>, key: DefId) -> Fubar<'tcx> { ... }
+fn fubar<'tcx>(tcx: TyCtxt<'tcx>, key: DefId) -> Fubar<'tcx> { ... }
 ```
 
 N.B. Most of the `rustc_*` crates only provide **local

--- a/src/type-inference.md
+++ b/src/type-inference.md
@@ -50,9 +50,8 @@ function and disposed of after it returns.
 
 [ty-ch]: ty.html
 
-Within the closure, `infcx` has the type `InferCtxt<'cx, 'gcx, 'tcx>`
-for some fresh `'cx` and `'tcx` – the latter corresponds to the lifetime of
-this temporary arena, and the `'cx` is the lifetime of the `InferCtxt` itself.
+Within the closure, `infcx` has the type `InferCtxt<'cx, 'tcx>` for some
+fresh `'cx`, while `'tcx` is the same as outside the inference context.
 (Again, see the [`ty` chapter][ty-ch] for more details on this setup.)
 
 The `tcx.infer_ctxt` method actually returns a builder, which means


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/61722 and https://github.com/rust-lang/rust/pull/61817 for some backstory.

cc @mark-i-m @rust-lang/compiler