### PR TITLE
Blacklist some commonly problematic links

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -9,4 +9,4 @@ description = "A guide to developing rustc"
 
 [output.linkcheck]
 follow-web-links = true
-exclude = [ "crates\\.io", "gcc\\.godbolt\\.org" ]
+exclude = [ "crates\\.io", "gcc\\.godbolt\\.org", "youtube\\.com", "dl\\.acm\\.org" ]


### PR DESCRIPTION
I think for now, the proper policy to follow is to blacklist links that fail often, especially when they are unlikely to change often.

We may also want to include a warning about unchecked links... or we could just let people find them for us...

cc #385 #249 