### PR TITLE
Updated the mdbook-linkcheck version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ rust:
 - nightly
 cache:
 - cargo
+- directories:
+  - book/linkcheck/
 before_install:
 - shopt -s globstar
 - MAX_LINE_LENGTH=100 bash ci/check_line_lengths.sh src/**/*.md

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -21,4 +21,4 @@ function cargo_install() {
 }
 
 cargo_install mdbook 0.3.1
-cargo_install mdbook-linkcheck 0.3.1
+cargo_install mdbook-linkcheck 0.4.0


### PR DESCRIPTION
I recently rewrote large chunks of `mdbook-linkcheck` to take advantage of caching and parallelism, and thought you might want to take advantage of it for CI.

I'm not sure how this would interact with [these lines](https://github.com/rust-lang/rustc-guide/blob/78b63d19e57cfe3b309d6bf394640dfc193f403e/ci/build-ignore-timeouts.sh#L14-L15) in the `build-ignore-timeouts.sh` script, though.