### PR TITLE
Fix a link in the query docs.

### DIFF
--- a/src/query.md
+++ b/src/query.md
@@ -35,9 +35,9 @@ will in turn demand information about that crate, starting from the
 However, that vision is not fully realized. Still, big chunks of the
 compiler (for example, generating MIR) work exactly like this.
 
-### The Query Evaluation Model in Detail
+### Incremental Compilation in Detail
 
-The [Query Evaluation Model in Detail][query-model] chapter gives a more
+The [Incremental Compilation in Detail][query-model] chapter gives a more
 in-depth description of what queries are and how they work.
 If you intend to write a query of your own, this is a good read.
 
@@ -277,4 +277,4 @@ rustc_queries! {
 
 `rustc_queries` macro will generate an appropriate `impl` automatically.
 
-[query-model]: queries/query-evaluation-model-in-detail.html
+[query-model]: queries/incremental-compilation-in-detail.md


### PR DESCRIPTION
I'm not sure why the link checker didn't catch this...

There are a couple of other broken links I've not touched too:
```
error: Unable to retrieve "https://public.etherpad-mozilla.org/p/rust-compiler-meeting": https://public.e
therpad-mozilla.org/p/rust-compiler-meeting: error trying to connect: Connection refused (os error 111)
- compiler-team.md:32:1                                                                                 
   |                                                                                                    
32 | [the rust-compiler-meeting etherpad][etherpad]. It works roughly as                                
   |                                                                                                    
```

^ Genuinely a dead link.

```
error: Unable to retrieve "http://www.cs.bgu.ac.il/%7Ehendlerd/papers/p280-hendler.pdf": https://www.cs.b
gu.ac.il/%7Ehendlerd/papers/p280-hendler.pdf: error trying to connect: error:141A318A:SSL routines:tls_pr
ocess_ske_dhe:dh key too small:../ssl/statem/statem_clnt.c:2156:         
- appendix/bibliography.md:33:3                                          
   |                                                                       
33 | * [Non-blocking steal-half work queues](http://www.cs.bgu.ac.il/%7Ehendlerd/papers/p280-hendler.pdf)
   |                                                                             
```

^ Link works for me.