### PR TITLE
minor typo fixes

### DIFF
--- a/src/mir/construction.md
+++ b/src/mir/construction.md
@@ -92,7 +92,7 @@ There are essentially four kinds of representations one might want of an express
 * `Operand` is an argument to e.g. a `+` operation or a function call
 * a temporary variable containing a copy of the value
 
-These following image depicts a general overview of the interactions between the
+The following image depicts a general overview of the interactions between the
 representations:
 
 <img src="mir_overview.svg">

--- a/src/mir/passes.md
+++ b/src/mir/passes.md
@@ -26,8 +26,8 @@ where we want to access the MIR for type checking or other purposes:
 
 A `MirPass` is some bit of code that processes the MIR, typically –
 but not always – transforming it along the way somehow. For example,
-it might perform an optimization. The `MirPass` trait itself is found
-in in [the `rustc_mir::transform` module][mirtransform], and it
+it might perform an optimization. The `MirPass` trait itself is found 
+in [the `rustc_mir::transform` module][mirtransform], and it
 basically consists of one method, `run_pass`, that simply gets an
 `&mut Mir` (along with the tcx and some information about where it
 came from). The MIR is therefore modified in place (which helps to

--- a/src/mir/passes.md
+++ b/src/mir/passes.md
@@ -26,7 +26,7 @@ where we want to access the MIR for type checking or other purposes:
 
 A `MirPass` is some bit of code that processes the MIR, typically –
 but not always – transforming it along the way somehow. For example,
-it might perform an optimization. The `MirPass` trait itself is found 
+it might perform an optimization. The `MirPass` trait itself is found
 in [the `rustc_mir::transform` module][mirtransform], and it
 basically consists of one method, `run_pass`, that simply gets an
 `&mut Mir` (along with the tcx and some information about where it

--- a/src/test-implementation.md
+++ b/src/test-implementation.md
@@ -24,8 +24,8 @@ mod my_priv_mod {
   }
 }
 ```
-Private items can thus be easily tested without worrying about how to expose
-the them to any sort of external testing apparatus. This is key to the
+Private items can thus be easily tested without worrying about how to expose 
+them to any sort of external testing apparatus. This is key to the
 ergonomics of testing in Rust. Semantically, however, it's rather odd.
 How does any sort of `main` function invoke these tests if they're not visible?
 What exactly is `rustc --test` doing?

--- a/src/test-implementation.md
+++ b/src/test-implementation.md
@@ -24,7 +24,7 @@ mod my_priv_mod {
   }
 }
 ```
-Private items can thus be easily tested without worrying about how to expose 
+Private items can thus be easily tested without worrying about how to expose
 them to any sort of external testing apparatus. This is key to the
 ergonomics of testing in Rust. Semantically, however, it's rather odd.
 How does any sort of `main` function invoke these tests if they're not visible?


### PR DESCRIPTION
Found and fixed some minor typos in the rustc-guide. Thank you.