### PR TITLE
Fold subchapters

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -8,7 +8,9 @@ create-missing = false
 
 [output.html]
 
-[output.html.search]
+[output.html.fold]
+enable = true
+level = 1
 
 [output.linkcheck]
 follow-web-links = true


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8827840/68239851-5de44700-ffd1-11e9-80d8-ad4b82bcf8e0.png)

This makes the sidebar much shorter and more readable by default. One can still see the subchapters by clicking the little arrow to unfold the chapter.