### PR TITLE
Clarify function name and add links

### DIFF
--- a/src/rustc-driver.md
+++ b/src/rustc-driver.md
@@ -9,7 +9,7 @@ for running code at particular times during the compilation process, allowing
 third parties to effectively use `rustc`'s internals as a library for
 analysing a crate or emulating the compiler in-process (e.g. the RLS or rustdoc).
 
-For those using `rustc` as a library, the `interface::run_compiler()` function is the main
+For those using `rustc` as a library, the [`rustc_interface::interface::run_compiler()`][int_rc] function is the main
 entrypoint to the compiler. It takes a configuration for the compiler and a closure that
 takes a [`Compiler`]. `run_compiler` creates a `Compiler` from the configuration and passes
 it to the closure. Inside the closure, you can use the `Compiler` to drive queries to compile
@@ -18,7 +18,7 @@ a crate and get the results. This is what the `rustc_driver` does too.
 You can see what queries are currently available through the rustdocs for [`Compiler`].
 You can see an example of how to use them by looking at the `rustc_driver` implementation,
 specifically the [`rustc_driver::run_compiler` function][rd_rc] (not to be confused with
-`interface::run_compiler`). The `rustc_driver::run_compiler` function takes a bunch of
+[`rustc_interface::interface::run_compiler`][int_rc]). The `rustc_driver::run_compiler` function takes a bunch of
 command-line args and some other configurations and drives the compilation to completion.
 
 `rustc_driver::run_compiler` also takes a [`Callbacks`][cb]. In the past, when
@@ -47,6 +47,7 @@ thread-locals, although you should rarely need to touch it.
 
 [cb]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_driver/trait.Callbacks.html
 [rd_rc]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_driver/fn.run_compiler.html
+[int_rc]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_interface/interface/fn.run_compiler.html
 [`rustc_interface`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_interface/index.html
 [`rustc_driver`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_driver/
 [`Compiler`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_interface/interface/struct.Compiler.html

--- a/src/rustc-driver.md
+++ b/src/rustc-driver.md
@@ -9,8 +9,8 @@ for running code at particular times during the compilation process, allowing
 third parties to effectively use `rustc`'s internals as a library for
 analysing a crate or emulating the compiler in-process (e.g. the RLS or rustdoc).
 
-For those using `rustc` as a library, the [`rustc_interface::interface::run_compiler()`][int_rc] function is the main
-entrypoint to the compiler. It takes a configuration for the compiler and a closure that
+For those using `rustc` as a library, the [`rustc_interface::interface::run_compiler()`][i_rc] function
+is the main entrypoint to the compiler. It takes a configuration for the compiler and a closure that
 takes a [`Compiler`]. `run_compiler` creates a `Compiler` from the configuration and passes
 it to the closure. Inside the closure, you can use the `Compiler` to drive queries to compile
 a crate and get the results. This is what the `rustc_driver` does too.
@@ -18,8 +18,8 @@ a crate and get the results. This is what the `rustc_driver` does too.
 You can see what queries are currently available through the rustdocs for [`Compiler`].
 You can see an example of how to use them by looking at the `rustc_driver` implementation,
 specifically the [`rustc_driver::run_compiler` function][rd_rc] (not to be confused with
-[`rustc_interface::interface::run_compiler`][int_rc]). The `rustc_driver::run_compiler` function takes a bunch of
-command-line args and some other configurations and drives the compilation to completion.
+[`rustc_interface::interface::run_compiler`][i_rc]). The `rustc_driver::run_compiler` function takes
+a bunch of command-line args and some other configurations and drives the compilation to completion.
 
 `rustc_driver::run_compiler` also takes a [`Callbacks`][cb]. In the past, when
 the `rustc_driver::run_compiler` was the primary way to use the compiler as a
@@ -47,7 +47,7 @@ thread-locals, although you should rarely need to touch it.
 
 [cb]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_driver/trait.Callbacks.html
 [rd_rc]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_driver/fn.run_compiler.html
-[int_rc]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_interface/interface/fn.run_compiler.html
+[i_rc]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_interface/interface/fn.run_compiler.html
 [`rustc_interface`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_interface/index.html
 [`rustc_driver`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_driver/
 [`Compiler`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_interface/interface/struct.Compiler.html

--- a/src/rustc-driver.md
+++ b/src/rustc-driver.md
@@ -9,17 +9,18 @@ for running code at particular times during the compilation process, allowing
 third parties to effectively use `rustc`'s internals as a library for
 analysing a crate or emulating the compiler in-process (e.g. the RLS or rustdoc).
 
-For those using `rustc` as a library, the [`rustc_interface::interface::run_compiler()`][i_rc] function
-is the main entrypoint to the compiler. It takes a configuration for the compiler and a closure that
-takes a [`Compiler`]. `run_compiler` creates a `Compiler` from the configuration and passes
-it to the closure. Inside the closure, you can use the `Compiler` to drive queries to compile
-a crate and get the results. This is what the `rustc_driver` does too.
+For those using `rustc` as a library, the [`rustc_interface::interface::run_compiler()`][i_rc]
+function is the main entrypoint to the compiler. It takes a configuration for the compiler
+and a closure that takes a [`Compiler`]. `run_compiler` creates a `Compiler` from the 
+configuration and passes it to the closure. Inside the closure, you can use the `Compiler`
+to drive queries to compile a crate and get the results. This is what the `rustc_driver` does too.
 
 You can see what queries are currently available through the rustdocs for [`Compiler`].
 You can see an example of how to use them by looking at the `rustc_driver` implementation,
 specifically the [`rustc_driver::run_compiler` function][rd_rc] (not to be confused with
-[`rustc_interface::interface::run_compiler`][i_rc]). The `rustc_driver::run_compiler` function takes
-a bunch of command-line args and some other configurations and drives the compilation to completion.
+[`rustc_interface::interface::run_compiler`][i_rc]). The `rustc_driver::run_compiler` function 
+takes a bunch of command-line args and some other configurations and
+drives the compilation to completion.
 
 `rustc_driver::run_compiler` also takes a [`Callbacks`][cb]. In the past, when
 the `rustc_driver::run_compiler` was the primary way to use the compiler as a


### PR DESCRIPTION
rustc_interface::interface::run_compiler 
(https://doc.rust-lang.org/nightly/nightly-rustc/rustc_interface/interface/fn.run_compiler.html)