### PR TITLE
Mark feature description comment as a doc comment

### DIFF
--- a/src/implementing_new_features.md
+++ b/src/implementing_new_features.md
@@ -129,7 +129,7 @@ a new unstable feature:
    in the active `declare_features` block:
 
    ```rust,ignore
-   // description of feature
+   /// description of feature
    (active, $feature_name, "$current_nightly_version", Some($tracking_issue_number), $edition)
    ```
 


### PR DESCRIPTION
In the *Implementing new features* chapter, we are shown the syntax for the declaration of a feature in the `declare_features` block:

```rust
// description of feature
(active, $feature_name, "$current_nightly_version", Some($tracking_issue_number), $edition)
```

The description in this code is written in a "plain" comment. However, in the [`librustc_feature/active.rs`][active] file, features are documented using documentation comments instead of "plain" comments. As the snippet is probably meant for copy-pasting, I thought this small detail might need to be fixed.

[active]: https://github.com/rust-lang/rust/blob/master/src/librustc_feature/active.rs