### PR TITLE
Update ./x.py tidy testing documentation

### DIFF
--- a/src/conventions.md
+++ b/src/conventions.md
@@ -12,7 +12,7 @@ at the moment, however, it follows a rather more *chaotic* style.  We
 do have some mandatory formatting conventions, which are automatically
 enforced by a script we affectionately call the "tidy" script.  The
 tidy script runs automatically when you do `./x.py test` and can be run
-in isolation with `./x.py test src/tools/tidy`.
+in isolation with `./x.py test tidy`.
 
 [fmt]: https://github.com/rust-lang-nursery/fmt-rfcs
 

--- a/src/diagnostics/diagnostic-codes.md
+++ b/src/diagnostics/diagnostic-codes.md
@@ -12,7 +12,7 @@ code. This is a bit tricky since the codes are defined in various crates. To do
 it, run this obscure command:
 
 ```
-./x.py test --stage 0 src/tools/tidy
+./x.py test --stage 0 tidy
 ```
 
 This will invoke the tidy script, which generally checks that your code obeys

--- a/src/tests/intro.md
+++ b/src/tests/intro.md
@@ -61,7 +61,7 @@ including:
   There is more information in the
   [section on coding conventions](../conventions.html#formatting).
 
-  Example: `./x.py test src/tools/tidy`
+  Example: `./x.py test tidy`
 
 - **Formatting** – Rustfmt is integrated with the build system to enforce
   uniform style across the compiler. In the CI, we check that the formatting
@@ -73,7 +73,7 @@ including:
 
   Example: `./x.py fmt` runs rustfmt on the codebase.
 
-  Example: `./x.py test src/tools/tidy --bless` does formatting before doing
+  Example: `./x.py test tidy --bless` does formatting before doing
   other tidy checks.
 
 - **Unit tests** – The Rust standard library and many of the Rust packages

--- a/src/tests/running.md
+++ b/src/tests/running.md
@@ -72,10 +72,10 @@ Likewise, you can test a single file by passing its path:
 ./x.py test src/libstd
 ```
 
-### Run tests on the standard library and run the tidy script
+### Run the tidy script and tests on the standard library
 
 ```bash
-./x.py test src/libstd src/tools/tidy
+./x.py test tidy src/libstd
 ```
 
 ### Run tests on the standard library using a stage 1 compiler

--- a/src/tests/running.md
+++ b/src/tests/running.md
@@ -63,7 +63,7 @@ Likewise, you can test a single file by passing its path:
 ### Run only the tidy script
 
 ```bash
-./x.py test src/tools/tidy
+./x.py test tidy
 ```
 
 ### Run tests on the standard library


### PR DESCRIPTION
We are updating the rust repository `./x.py test` docs to use the `tidy` argument in https://github.com/rust-lang/rust/pull/69603:

```
./x.py test tidy
```

This replaces the previous recommendation to use the source directory path:

```
./x.py test src/tools/tidy
```

This PR updates the rustc-dev-guide docs to use the same recommendation.